### PR TITLE
Strict declarations for classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "7workers/petty-rest",
   "description": "Limited and very basic REST client",
-  "version": "2.1.1",
+  "version": "2.2.2",
   "type": "library",
   "license": "MIT",
   "authors": [
@@ -11,7 +11,7 @@
     }
   ],
   "require": {
-    "php": ">=7.1",
+    "php": ">=7.4",
     "ext-json": ">=1.2.0",
     "psr/http-client": "^1.0"
   },

--- a/src/Client.php
+++ b/src/Client.php
@@ -14,12 +14,12 @@ abstract class Client implements ClientInterface
 {
     abstract protected function getExceptionClass(\Throwable $e):string;
 
-    public $timeout = 1;
-    public $forceScheme;
+    public int $timeout = 1;
+    public ?string $forceScheme = null;
 
-    protected $host;
-    protected $apiKey;
-    protected $targetPrefix;
+    protected string $host;
+    protected string $apiKey;
+    protected ?string $targetPrefix = null;
 
     public function __construct(string $host, string $apiKey)
     {

--- a/src/Request.php
+++ b/src/Request.php
@@ -1,16 +1,17 @@
 <?php /** @noinspection DuplicatedCode */ /** @noinspection PhpToStringReturnInspection */ /** @noinspection PhpMissingReturnTypeInspection */ /** @noinspection PhpDocRedundantThrowsInspection */ /** @noinspection ReturnTypeCanBeDeclaredInspection */
 namespace PettyRest;
+use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
 abstract class Request implements RequestInterface
 {
-    protected $method = 'POST';
-    protected $scheme = 'https';
-    protected $target;
-    protected $host;
-    protected $bodyJson;
-    protected $arHeaders;
+    protected string $method = 'POST';
+    protected string $scheme = 'https';
+    protected string $target;
+    protected string $host;
+    protected string $bodyJson;
+    protected array $arHeaders;
 
     abstract public function getResponseDummy(): Response;
 
@@ -26,63 +27,63 @@ abstract class Request implements RequestInterface
     public function setApiServerHost(string $host): void { $this->host = $host; }
     public function setApiServerScheme(string $s): void { $this->scheme = $s; }
     public function setTargetPrefix(string $prefix): void { $this->target = $prefix.$this->target; }
-    public function getHeaders(){return $this->arHeaders;}
-    public function withUri(UriInterface $uri,$preserveHost=false){return $this;}
-    public function hasHeader($name){return false;}
-    public function getHeader($name){return $this->arHeaders[$name]??null;}
-    public function getHeaderLine($name){return '';}
-    public function withHeader($name,$value){ $new=clone $this;$new->arHeaders[$name]=[$value];return $new;}
-    public function withAddedHeader($name,$value){return $this;}
-    public function withoutHeader($name){return $this;}
-    public function withBody(StreamInterface $body){return $this;}
-    public function getRequestTarget(){return $this->target;}
-    public function withRequestTarget($requestTarget){return $this;}
-    public function getMethod(){return $this->method;}
-    public function withMethod($method){$this->method=$method;return $this;}
-    public function getProtocolVersion(){return '1.1';}
-    public function withProtocolVersion($version){return $this;}
-    public function getBody()
+    public function getHeaders(): array {return $this->arHeaders;}
+    public function withUri(UriInterface $uri, bool $preserveHost=false): RequestInterface {return $this;}
+    public function hasHeader(string $name): bool {return false;}
+    public function getHeader(string $name): array {return $this->arHeaders[$name]??[];}
+    public function getHeaderLine(string $name): string {return '';}
+    public function withHeader(string $name,$value): MessageInterface { $new=clone $this;$new->arHeaders[$name]=[$value];return $new;}
+    public function withAddedHeader(string $name,$value): MessageInterface {return $this;}
+    public function withoutHeader(string $name): MessageInterface {return $this;}
+    public function withBody(StreamInterface $body): MessageInterface {return $this;}
+    public function getRequestTarget(): string {return $this->target;}
+    public function withRequestTarget(string $requestTarget): RequestInterface {return $this;}
+    public function getMethod(): string {return $this->method;}
+    public function withMethod(string $method): RequestInterface {$this->method=$method;return $this;}
+    public function getProtocolVersion(): string {return '1.1';}
+    public function withProtocolVersion(string $version): MessageInterface {return $this;}
+    public function getBody(): StreamInterface
     {
         if(null===$this->bodyJson)$this->bodyJson=json_encode(array_filter(array_map(static function($in){if(!is_array($in))return $in;if(empty($in))return null;$in=array_filter($in,static function($x){if(null===$x)return false;if(is_array($x)&&empty($x))return false;return true;});if(empty($in))return null;return $in;},array_filter(get_object_vars($this),static function($k){return !in_array($k,['method','scheme','arHeaders','host','target','bodyJson']);},ARRAY_FILTER_USE_KEY)),static function($x){return null!==$x;}),JSON_UNESCAPED_SLASHES|JSON_UNESCAPED_UNICODE);
         return new class($this->bodyJson) implements StreamInterface{
             private $json;
             public function __construct($json){$this->json=$json;}
-            public function __toString(){return $this->json;}
-            public function getContents(){return $this->json;}
-            public function getSize(){return mb_strlen($this->json);}
-            public function close(){}
+            public function __toString(): string {return $this->json;}
+            public function getContents(): string {return $this->json;}
+            public function getSize(): ?int {return mb_strlen($this->json);}
+            public function close(): void {}
             public function detach(){}
-            public function tell(){return 0;}
-            public function eof(){return false;}
-            public function isSeekable(){return false;}
-            public function seek($offset,$whence=SEEK_SET){}
-            public function rewind(){}
-            public function isWritable(){return false;}
-            public function write($string){return 0;}
-            public function isReadable(){return false;}
-            public function read($length){}
-            public function getMetadata($key=null){return null;}};
+            public function tell(): int {return 0;}
+            public function eof(): bool {return false;}
+            public function isSeekable(): bool {return false;}
+            public function seek(int $offset, int $whence=SEEK_SET): void {}
+            public function rewind(): void {}
+            public function isWritable(): bool {return false;}
+            public function write(string $string): int {return 0;}
+            public function isReadable(): bool {return false;}
+            public function read(int $length): string {return '';}
+            public function getMetadata(?string $key=null){return null;}};
     }
-    public function getUri()
+    public function getUri(): UriInterface
     {
         return new class($this->host,$this->target,$this->scheme) implements UriInterface{
             private $h;private $p;private $s;
             public function __construct($h,$p,$s){$this->h=$h;$this->p=$p;$this->s=$s;}
-            public function getScheme(){return $this->s;}
-            public function getHost(){return $this->h;}
-            public function getPath(){return $this->p;}
-            public function __toString(){return $this->getScheme().'://'.$this->h.$this->p;}
-            public function getAuthority(){return'';}
-            public function getUserInfo(){return'';}
-            public function getPort(){return null;}
-            public function getQuery(){return'';}
-            public function getFragment(){return'';}
-            public function withScheme($scheme){return $this;}
-            public function withUserInfo($user,$password=null){return $this;}
-            public function withHost($host){return $this;}
-            public function withPort($port){return $this;}
-            public function withPath($path){return $this;}
-            public function withQuery($query){return $this;}
-            public function withFragment($fragment){return $this;}};
+            public function getScheme(): string {return $this->s;}
+            public function getHost(): string {return $this->h;}
+            public function getPath(): string {return $this->p;}
+            public function __toString(): string {return $this->getScheme().'://'.$this->h.$this->p;}
+            public function getAuthority(): string {return'';}
+            public function getUserInfo(): string {return'';}
+            public function getPort(): ?int {return null;}
+            public function getQuery(): string {return'';}
+            public function getFragment(): string {return'';}
+            public function withScheme(string $scheme): UriInterface {return $this;}
+            public function withUserInfo(string $user, ?string $password=null): UriInterface {return $this;}
+            public function withHost(string $host): UriInterface {return $this;}
+            public function withPort(?int $port): UriInterface {return $this;}
+            public function withPath(string $path): UriInterface {return $this;}
+            public function withQuery(string $query): UriInterface {return $this;}
+            public function withFragment(string $fragment): UriInterface {return $this;}};
     }
 }

--- a/src/Response.php
+++ b/src/Response.php
@@ -1,14 +1,15 @@
 <?php /** @noinspection PhpMissingReturnTypeInspection */ /** @noinspection PhpFullyQualifiedNameUsageInspection */ /** @noinspection PhpUnhandledExceptionInspection */ /** @noinspection PhpInconsistentReturnPointsInspection */ /** @noinspection ReturnTypeCanBeDeclaredInspection */ /** @noinspection PhpDocRedundantThrowsInspection */
 namespace PettyRest;
 
+use Psr\Http\Message\MessageInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 
 abstract class Response implements ResponseInterface
 {
-    public $rawResponse;
+    public string $rawResponse;
 
-    public function hydrateFromRaw(string $rawResponse)
+    public function hydrateFromRaw(string $rawResponse): void
     {
         $this->rawResponse = $rawResponse;
 
@@ -25,36 +26,36 @@ abstract class Response implements ResponseInterface
         foreach($d as $k=>$v){$this->{$k}=$v;}
     }
 
-    public function getProtocolVersion(){return '1.1';}
-    public function withProtocolVersion($version){return $this;}
-    public function getHeaders(){return [];}
-    public function hasHeader($name){return false;}
-    public function getHeader($name){return [];}
-    public function getHeaderLine($name){return '';}
-    public function withHeader($name,$value){return $this;}
-    public function withAddedHeader($name,$value){return $this;}
-    public function withoutHeader($name){return $this;}
-    public function getBody() {
+    public function getProtocolVersion(): string {return '1.1';}
+    public function withProtocolVersion(string $version): MessageInterface {return $this;}
+    public function getHeaders(): array {return [];}
+    public function hasHeader(string $name): bool {return false;}
+    public function getHeader(string $name): array {return [];}
+    public function getHeaderLine(string $name): string {return '';}
+    public function withHeader(string $name,$value): MessageInterface {return $this;}
+    public function withAddedHeader(string $name,$value): MessageInterface {return $this;}
+    public function withoutHeader(string $name): MessageInterface {return $this;}
+    public function getBody(): StreamInterface {
         return new class($this) implements StreamInterface {
             private $response;
             public function __construct($response){$this->response=$response;}
-            public function __toString(){return $this->getContents();}
-            public function close(){}
+            public function __toString(): string {return $this->getContents();}
+            public function close(): void {}
             public function detach(){}
-            public function getSize(){return null;}
-            public function tell(){return 0;}
-            public function eof(){return false;}
-            public function isSeekable(){return false;}
-            public function seek($offset,$whence=SEEK_SET){}
-            public function rewind(){}
-            public function isWritable(){return false;}
-            public function write($string){}
-            public function isReadable(){return false;}
-            public function read($length){}
-            public function getContents(){return @$this->response->rawResponse;}
-            public function getMetadata($key=null){return null;}};}
-    public function withBody(StreamInterface $body){return $this;}
-    public function getStatusCode(){return 202;}
-    public function withStatus($code,$reasonPhrase=''){return $this;}
-    public function getReasonPhrase(){return '';}
+            public function getSize(): ?int {return null;}
+            public function tell(): int {return 0;}
+            public function eof(): bool {return false;}
+            public function isSeekable(): bool {return false;}
+            public function seek(int $offset,int $whence=SEEK_SET): void {}
+            public function rewind(): void {}
+            public function isWritable(): bool {return false;}
+            public function write(string $string): int {return 0;}
+            public function isReadable():bool {return false;}
+            public function read(int $length): string {return '';}
+            public function getContents(): string {return @$this->response->rawResponse;}
+            public function getMetadata(?string $key=null){return null;}};}
+    public function withBody(StreamInterface $body): MessageInterface {return $this;}
+    public function getStatusCode(): int {return 202;}
+    public function withStatus(int $code, string $reasonPhrase=''): ResponseInterface {return $this;}
+    public function getReasonPhrase(): string {return '';}
 }


### PR DESCRIPTION
For all properties, parameters, and method return values of classes, added types as in parent classes (from the `psr/http-message` library).

I got PHP fatal errors on PHP 8.3 without these changes.